### PR TITLE
fix(docs): Correct broken benchmark links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@
 
 > [!IMPORTANT]  
 > :thumbsup: `3.1.0 版本`，利用非同步並發處理，爬取內文效率大增，依照測試結果，**時間可減少81%以上**。
- [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmark/benchmark.md)  
+ [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmarks/benchmark.md)  
 > `Version 3.1.0`: Utilizes asynchronous concurrent processing to
  significantly boost content crawling efficiency, **reducing
  processing time by over 81% according to our benchmark results**.
- [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmark/benchmark.md)  
+ [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmarks/benchmark.md)  
 > :thumbsup: `3.0.1 版本`，利用並發處理，爬取內文效率大增，依照測試結果，**時間可減少77%以上**。
- [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmark/benchmark.md)  
+ [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmarks/benchmark.md)  
 > `Version 3.0.1`: Utilizes concurrent processing to significantly
  boost content crawling efficiency, **reducing processing time by
  over 77% according to our benchmark results**.  
- [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmark/benchmark.md)  
+ [(Benchmark)](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmarks/benchmark.md)  
 > :bookmark: `3.x.x 版本`，主要利用「物件導向類別」進行使用，仍保留原本
 2.x.x版本的模組函式呼叫介面(如：initialize(), getResults(),...)。
 但是，**預計在4.0.0以後的版本，把原2.x.x版本函式(Deprecated)刪除，請留意！！！**  

--- a/benchmarks/benchmark.md
+++ b/benchmarks/benchmark.md
@@ -2,9 +2,9 @@
 
 |版本 (Ver.)|特徵 (Feat.)|測試檔案 (Test File)|測試時間 (Duration)|備註 (Notes)|
 |----------|------|----------|----------|---------|
-|v3.1.0|有並發 (w/ Concurrency)|[demo-v3.0.1.cjs](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmark/demo-v3.1.0.cjs)|3.4s, 14s, **1m25.7s**|分頁非同步 (Pages Asynchronous)|
-|v3.0.1|有並發 (w/ Concurrency)|[demo-v3.0.1.cjs](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmark/demo-v3.0.1.cjs)|4.9s, 19.4s, **1m42.7s**|分頁以同步 (Pages Synchronous)|
-|v2.7.2|無並發 (w/o Concurrency)|[demo-v2.7.2.cjs](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmark/demo-v2.7.2.cjs)|4.2s, 1m19.4s, **7m36.9s**|略 (N/A)|
+|v3.1.0|有並發 (w/ Concurrency)|[demo-v3.0.1.cjs](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmarks/demo-v3.1.0.cjs)|3.4s, 14s, **1m25.7s**|分頁非同步 (Pages Asynchronous)|
+|v3.0.1|有並發 (w/ Concurrency)|[demo-v3.0.1.cjs](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmarks/demo-v3.0.1.cjs)|4.9s, 19.4s, **1m42.7s**|分頁以同步 (Pages Synchronous)|
+|v2.7.2|無並發 (w/o Concurrency)|[demo-v2.7.2.cjs](https://github.com/WayneChang65/ptt-crawler/blob/master/benchmarks/demo-v2.7.2.cjs)|4.2s, 1m19.4s, **7m36.9s**|略 (N/A)|
 
 ## 測試條件 (Test Condition)  
 


### PR DESCRIPTION
- Updated the directory name from `benchmark/` to `benchmarks/` in URLs within `README.md` and `benchmarks/benchmark.md`.
- This ensures that the benchmark links point to the correct locations.